### PR TITLE
HTTPS and Secure WebSockets done

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,8 +20,8 @@ app.get('/', (req, res) => {
 });
 
 /* Handles terminal communication */
-const wsServer = new WebSocketServer({ noServer: true });
-wsServer.on('connection', (ws, req) => {
+const wss = new WebSocketServer({ noServer: true });
+wss.on('connection', (ws, req) => {
     if (req.url === '/wissh') {
         const shell = getShell();
         const ptyProcess = pty.spawn(shell, [], {
@@ -57,13 +57,13 @@ wsServer.on('connection', (ws, req) => {
 
 /* Handles HTTP requests and links `app` with `wsServer` */
 const server = https.createServer({
-    key: fs.readFileSync('/etc/ssl/private/key.pem'),
-    cert: fs.readFileSync('/etc/ssl/certs/certificate.pem')
+    cert: fs.readFileSync('/etc/ssl/certs/certificate.pem'),
+    key: fs.readFileSync('/etc/ssl/private/key.pem')
 }, app);
 
 server.on('upgrade', (request, socket, head) => {
-    wsServer.handleUpgrade(request, socket, head, (ws) => {
-        wsServer.emit('connection', ws, request);
+    wss.handleUpgrade(request, socket, head, (ws) => {
+        wss.emit('connection', ws, request);
     });
 });
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         }
 
         /* WebSocket */
-        const ws = new WebSocket(`ws://${window.location.host}/wissh`);
+        const ws = new WebSocket(`wss://${window.location.host}/wissh`);
         ws.onopen = (event) => {
             xtermFitAddon.fit();
             ws.send(JSON.stringify({ resize: { cols: terminal.cols, rows: terminal.rows } }));


### PR DESCRIPTION
Enabled HTTPS and configured secure WebSockets. Server now runs on `https://localhost:8080`. Used Wireshark to verify that the packets are indeed encrypted and unintelligible.